### PR TITLE
Focus fixes and styles from accessibilityfixes script

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,15 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "compat-api/css": [
+      "default",
+      {
+        "ignore": [
+          "-webkit-filter"
+        ]
+      }
+    ]
+  }
+}

--- a/less/custom/theme-extras.less
+++ b/less/custom/theme-extras.less
@@ -23,6 +23,7 @@
 //      [&&13] SPECIFIC - EXPOSE COMPONENT
 //      [&&14] SPECIFIC - MATCHING COMPONENT
 //      [&&15] SPECIFIC - OPEN TEXT COMPONENT
+//      [&&16] SPECIFIC - LEARNERS PICK
 // [^^] - UTILITY
 // [//] - CUSTOM
 
@@ -220,6 +221,17 @@ html{
     }
 }
 
+// MARGINS
+// Option to remove max-width on blocks
+.block .block-inner when (@margin-control = 'No Margin') {
+    max-width: 100%;  
+}
+ 
+.article .article-header when (@margin-control = 'No Margin') {
+    max-width: calc(100% - 150px);
+}
+
+
 // ARTICLE LEVEL 
 .article {
     .article-inner{
@@ -278,11 +290,11 @@ html{
 }
 
 // BLOCK LEVEL
-.block-padding when (@improved-block-padding = Legacy) {
+.block-padding when (@improved-block-padding = 'Legacy') {
     padding: 60px;
- }
- 
-.block-padding when (@improved-block-padding = Improved) {
+}
+
+.block-padding when (@improved-block-padding = 'Improved') {
     padding: 40px 60px;
 }
         
@@ -579,13 +591,22 @@ html *:focus, body div:focus, body p:focus, body button:focus, body label:focus,
     outline:3px solid #CD1C6A !important;
 }
 
-// visible focus indicator outline on title
-html:not(.a11y-disable-focusoutline) .js-heading-inner:focus {
-    outline: none!important;
-}
-
-html:not(.a11y-disable-focusoutline) .js-heading:focus-within ~ .component-title-inner {
-    outline: 3px solid #CD1C6A !important;
+//fixed visible focus indicator on titles (previously on invisible aria-label)
+html:not(.a11y-disable-focusoutline) {
+    .js-heading {
+        &:focus-within {
+            //focus indicator visible on component title when child aria-label is focused
+            ~.component-title-inner {
+                outline: 3px solid @esdc-pink !important;
+            }
+        }
+    }
+    .js-heading-inner {
+        // visible focus indicator outline on visible title instead of not visible aria-label
+        &:focus {
+            outline: none !important;
+        }
+    }
 }
 
 
@@ -842,6 +863,30 @@ button.hotgrid-grid-item .hotgrid-item-title{
     height:400px !important;
  }
 
+ // hotgrapgic and hotgrid focus indicator fixes for new popup focus
+html:not(.a11y-disable-focusoutline) {
+    .notify-popup {
+        /* adds focus indicator to hotgrid-popup instead of notify-popup when hotgrid or hotgraphic */
+        &:focus {
+            .hotgrid-popup , .hotgraphic-popup {
+                outline: 3px solid @esdc-pink !important;
+            }
+        }
+        /* removes focus indicator from notify-popup when hotgrid or hotgraphic */
+        &:has(.hotgrid-popup):focus, &:has(.hotgraphic-popup):focus {
+            outline: none !important;
+        }
+        /* adds focus indicator to hotgrid-popup instead of title when hotgrid or hotgraphic */
+        .hotgrid-popup:has(.hotgrid-content-title:focus), .hotgraphic-popup:has(.hotgraphic-content-title:focus) {
+            outline: 3px solid @esdc-pink !important;
+        }
+        /* removes focus indicator from content-title when hotgrid or hotgraphic */
+        .hotgrid-content-title:focus,.hotgraphic-content-title:focus {
+            outline: none !important;
+        }
+    }
+}
+
 // ====================================================================
 //
 // [&&12] SPECIFIC - IMAGE SLIDER
@@ -902,6 +947,33 @@ button.hotgrid-grid-item .hotgrid-item-title{
     .buttons .buttons-marking-icon {
         left: 90% !important;
     }
+}
+
+// ====================================================================
+//
+// [&&16] SPECIFIC - LEARNERS PICK
+//
+// ====================================================================
+.bubble-answer {
+    background: #fff;
+    color: #0F2A4A;
+    font-weight: bold;
+    padding: 7.5px 15px;
+    display: inline-block;
+    margin: 0;
+    border-radius: 20px;
+    font-size: 95%;
+}
+
+.icon-answer {
+    display: flex;
+    align-items: center;
+    font-weight: bold;
+    font-size: 95%;
+}
+
+.info-icon {
+    margin-right: 10px;
 }
 
 // ====================================================================

--- a/less/custom/theme-extras.less
+++ b/less/custom/theme-extras.less
@@ -489,10 +489,18 @@ abbr[title] {
 }
 
 // COMPONENT LEVEL
-.component .component-instruction-inner.validation-error {
-    color: #a94442;
-    border: 2px solid #a94442;
+
+.component .component-instruction-inner {
     padding: 5px;
+}
+
+.component .component-instruction-inner.validation-error {
+    color: #000000 !important;
+    background: #f3e9e8;
+    border-top: none!important;
+    border-bottom: none!important;
+    border-right: none!important;
+    border-left: 4px solid #d3080c!important;
 }
 
 // Link styles
@@ -544,6 +552,9 @@ abbr[title] {
     .notify-popup-icon-close:hover {
         color:lighten(@esdc-pink,20%) !important;
     }
+    a {
+        text-decoration: underline!important;
+    }
 }
 
 // non interactive box
@@ -562,6 +573,21 @@ button, label, input, .mcq-item input:focus + label {
         outline:3px solid @esdc-pink !important;
     }
 }
+
+//visible focus indicator on all interactive elements
+html *:focus, body div:focus, body p:focus, body button:focus, body label:focus, body input:focus, body *:focus {
+    outline:3px solid #CD1C6A !important;
+}
+
+// visible focus indicator outline on title
+html:not(.a11y-disable-focusoutline) .js-heading-inner:focus {
+    outline: none!important;
+}
+
+html:not(.a11y-disable-focusoutline) .js-heading:focus-within ~ .component-title-inner {
+    outline: 3px solid #CD1C6A !important;
+}
+
 
 // ====================================================================
 //
@@ -712,6 +738,7 @@ video::cue {
 .mcq-widget[role="radiogroup"]:focus-within, .mcq-widget[role="group"]>.mcq-item:focus-within {
     outline: 3px solid @esdc-pink;
 }
+
 
 // secondary focus for radio buttons
 .mcq-component div[role="radiogroup"] {
@@ -909,6 +936,11 @@ button.hotgrid-grid-item .hotgrid-item-title{
             color:#BDFFEB !important; // @esdc-cyan
         }
     }
+}
+
+//margin for submit button - used for Open Text Input fixes
+.button-margin {
+    margin-right:.5%
 }
 
 // ====================================================================

--- a/less/variables/generic.less
+++ b/less/variables/generic.less
@@ -23,4 +23,5 @@
 // Theme Configurations Default Values
 // ===================================
 
-@improved-block-padding: Improved;
+@improved-block-padding: 'Legacy';
+@margin-control: 'Default Size';

--- a/properties.schema
+++ b/properties.schema
@@ -30,16 +30,32 @@
           "improved-block-padding": {
             "type": "string",
             "required": true,
-            "default" : "Improved",
+            "default" : "'Legacy'",
             "title" : "Block Padding",
             "validators": [],
             "inputType": {
               "type": "Select",
               "options": [
-                "Improved",
-                "Legacy"
+                "'Legacy'",
+                "'Improved'"
               ]
-            }
+            },
+            "help": "The option Improved adjusts the spacing on top of block titles to make it even with the other sides. The option Legacy keeps Adapt's default spacing"
+          },
+          "margin-control": {
+            "type": "string",
+            "required": true,
+            "default" : "'Default Size'",
+            "title" : "Margin Size",
+            "validators": [],
+            "inputType": {
+              "type": "Select",
+              "options": [
+                "'Default Size'",
+                "'No Margin'"
+              ]
+            },
+            "help": "The option No Margin removes the left and right margin on the course. WARNING: If you activate this option on an existing course, images that are smaller will need to be replaced by larger ones. The pins in your hotgrid components may need repositioning."
           }
         }
       }


### PR DESCRIPTION
**focus adjustments and moved styles**
changed focus indicator on visible title while keeping actual focus on aria-label
changed validation style to make it different than the focus outline style
moved styles in tempFixes() from adapt-accessibilityFixes to adapt-college-theme
fixed links missing underline in some popups

**Focus indicator and margin size control**
added focus indicator classes for the new focus control on popups
reworked some focus indicator classes to use LESS for better readability
added theme option for margin size control (implemented with quotes)
added LESS classes for margin size control
reworked block padding theme option to work with quotes too
added help messages and warnings for options